### PR TITLE
fix: \r is inserted in the View on Windows

### DIFF
--- a/LuaFormatter.py
+++ b/LuaFormatter.py
@@ -27,7 +27,12 @@ class LuaFormatCommand(sublime_plugin.TextCommand):
         output = bytes.decode(process.stdout.read())
         error = bytes.decode(process.stderr.read())
         if error == "":
-            self.view.replace(edit, sublime.Region(0, self.view.size()), output)
+            self.view.replace(
+                edit,
+                sublime.Region(0, self.view.size()),
+                # ST always uses \n in the text buffer
+                output.replace("\r\n", "\n"),
+            )
         else:
             sublime.error_message(error)
 

--- a/LuaFormatter.py
+++ b/LuaFormatter.py
@@ -1,6 +1,9 @@
 import os
-import sublime, sublime_plugin, sys
+import sublime
+import sublime_plugin
 import subprocess
+import sys
+
 
 class LuaFormatCommand(sublime_plugin.TextCommand):
     def run(self, edit, error=True, save=True):
@@ -24,13 +27,14 @@ class LuaFormatCommand(sublime_plugin.TextCommand):
         output = bytes.decode(process.stdout.read())
         error = bytes.decode(process.stderr.read())
         if error == "":
-          self.view.replace(edit, sublime.Region(0, self.view.size()), output)
+            self.view.replace(edit, sublime.Region(0, self.view.size()), output)
         else:
-          sublime.error_message(error)
+            sublime.error_message(error)
+
 
 class LuaFormatOnPreSave(sublime_plugin.EventListener):
     def on_pre_save(self, view):
-        if view.file_name().endswith('.lua'):
+        if view.file_name().endswith(".lua"):
             config = sublime.load_settings("LuaFormatter.sublime-settings")
             if config.get("auto_format_on_save", False):
                 view.run_command("lua_format")


### PR DESCRIPTION
ST always uses `\n` in the text buffer and it will auto use the proper line ending (only) when saving the file. 

---

Fixes https://github.com/Koihik/sublime-lua-format/issues/8